### PR TITLE
Extended QueryResults tuple instances to size 15

### DIFF
--- a/mysql-simple.cabal
+++ b/mysql-simple.cabal
@@ -1,5 +1,5 @@
 name:           mysql-simple
-version:        0.2.2.5
+version:        0.2.2.4
 homepage:       https://github.com/bos/mysql-simple
 bug-reports:    https://github.com/bos/mysql-simple/issues
 synopsis:       A mid-level MySQL client library.


### PR DESCRIPTION
I have added QueryResults instances for tuple types of size up to 15 (before they were defined up to 10). I may add more in the future if I need them.
