### PR TITLE
Add fieldName to other errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+cabal-dev
+dist
+.cabal-sandbox
+cabal.sandbox.config
+TAGS
+*~
+.stack-work

--- a/Database/MySQL/Simple/QueryResults.hs
+++ b/Database/MySQL/Simple/QueryResults.hs
@@ -23,7 +23,7 @@ module Database.MySQL.Simple.QueryResults
 import Control.Exception (throw)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B
-import Database.MySQL.Base.Types (Field(fieldType))
+import Database.MySQL.Base.Types (Field(fieldType, fieldName))
 import Database.MySQL.Simple.Result (ResultError(..), Result(..))
 import Database.MySQL.Simple.Types (Only(..))
 
@@ -357,6 +357,7 @@ convertError fs vs n = throw $ ConversionFailed
     (show (length fs) ++ " values: " ++ show (zip (map fieldType fs)
                                                   (map (fmap ellipsis) vs)))
     (show n ++ " slots in target type")
+    (show (map (B.unpack . fieldName) fs))
     "mismatch between number of columns to convert and number in target type"
 
 ellipsis :: ByteString -> ByteString

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,7 @@
+flags:
+  mysql-simple:
+    developer: false
+packages:
+- '.'
+extra-deps: []
+resolver: lts-2.16


### PR DESCRIPTION
This commit is a continuation of [previous work](https://github.com/bos/mysql-simple/pull/18), it also adds fieldName to two more exceptions, so that now, when you have some query involving many fields (lots of them), you have a sense of which field exactly caused an error.

Example of an error with this patch:

```
MySQLError (UnexpectedNull {errSQLType = "Long", errHaskellType = "Int", errFieldName = "locality_id", errMessage = ""})
```

It makes life much better to know which field exactly (locality_id) was null.

This patch also has few changes to add more stuff to .gitignore, and also adds stack.yaml for convenience of building project with `stack build` command for those who use stack.