### PR TITLE
Add type for variable length argument lists

### DIFF
--- a/Database/MySQL/Simple.hs
+++ b/Database/MySQL/Simple.hs
@@ -48,6 +48,7 @@ module Database.MySQL.Simple
     , Connection
     , Query
     , In(..)
+    , VaArgs(..)
     , Binary(..)
     , Only(..)
     -- ** Exceptions
@@ -97,7 +98,7 @@ import Database.MySQL.Simple.Param (Action(..), inQuotes)
 import Database.MySQL.Simple.QueryParams (QueryParams(..))
 import Database.MySQL.Simple.QueryResults (QueryResults(..))
 import Database.MySQL.Simple.Result (ResultError(..))
-import Database.MySQL.Simple.Types (Binary(..), In(..), Only(..), Query(..))
+import Database.MySQL.Simple.Types (Binary(..), In(..), VaArgs(..), Only(..), Query(..))
 import Text.Regex.PCRE.Light (compile, caseless, match)
 import qualified Data.ByteString.Char8 as B
 import qualified Database.MySQL.Base as Base

--- a/Database/MySQL/Simple/Param.hs
+++ b/Database/MySQL/Simple/Param.hs
@@ -34,7 +34,7 @@ import Data.Time.Format (formatTime)
 import Data.Time.LocalTime (TimeOfDay)
 import Data.Typeable (Typeable)
 import Data.Word (Word, Word8, Word16, Word32, Word64)
-import Database.MySQL.Simple.Types (Binary(..), In(..), Null)
+import Database.MySQL.Simple.Types (Binary(..), In(..), VaArgs(..), Null)
 import qualified Blaze.ByteString.Builder.Char.Utf8 as Utf8
 import qualified Data.ByteString as SB
 import qualified Data.ByteString.Lazy as LB
@@ -88,6 +88,11 @@ instance (Param a) => Param (In [a]) where
         Plain (fromChar '(') :
         (intersperse (Plain (fromChar ',')) . map render $ xs) ++
         [Plain (fromChar ')')]
+
+instance (Param a) => Param (VaArgs [a]) where
+    render (VaArgs []) = Plain $ fromByteString "null"
+    render (VaArgs xs) = Many $
+        intersperse (Plain (fromChar ',')) . map render $ xs
 
 instance Param (Binary SB.ByteString) where
     render (Binary bs) = Plain $ fromByteString "x'" `mappend`

--- a/Database/MySQL/Simple/Types.hs
+++ b/Database/MySQL/Simple/Types.hs
@@ -15,6 +15,7 @@ module Database.MySQL.Simple.Types
       Null(..)
     , Only(..)
     , In(..)
+    , VaArgs(..)
     , Binary(..)
     , Query(..)
     ) where
@@ -99,6 +100,18 @@ newtype Only a = Only {
 -- > query c "select * from whatever where id in ?" (Only (In [3,4,5]))
 newtype In a = In a
     deriving (Eq, Ord, Read, Show, Typeable, Functor)
+
+-- | Wrap a list of values for use in a function with variable arguments.
+-- Replaces a single \"@?@\" character with a non-parenthesized list of
+-- rendered values.
+--
+-- Example:
+--
+-- > query conn
+-- >   "SELECT * FROM example_table ORDER BY field(f,?)"
+-- >   (Only (VaArgs [3,2,1]))
+newtype VaArgs a = VaArgs a
+  deriving (Eq, Ord, Read, Show, Typeable, Functor)
 
 -- | Wrap a mostly-binary string to be escaped in hexadecimal.
 newtype Binary a = Binary a


### PR DESCRIPTION
As described in https://github.com/bos/mysql-simple/issues/30
The solution was another newtype similar to `In`, the difference being that its `Param` instance does not surround the parameters with parentheses.