### PR TITLE
Parse datetimes/timestamps with fractional seconds.

### DIFF
--- a/Database/MySQL/Simple/Result.hs
+++ b/Database/MySQL/Simple/Result.hs
@@ -39,7 +39,7 @@ import Data.List (foldl')
 import Data.Ratio (Ratio)
 import Data.Time.Calendar (Day, fromGregorian)
 import Data.Time.Clock (UTCTime(..))
-import Data.Time.Format (parseTimeM)
+import Data.Time.Format (parseTime)
 import Data.Time.LocalTime (TimeOfDay, makeTimeOfDayValid)
 import Data.Typeable (TypeRep, Typeable, typeOf)
 import Data.Word (Word, Word8, Word16, Word32, Word64)
@@ -162,7 +162,7 @@ instance Result [Char] where
 
 instance Result UTCTime where
     convert f = doConvert f ok $ \bs ->
-                case parseTimeM False defaultTimeLocale "%F %T%Q" (B8.unpack bs) of
+                case parseTime defaultTimeLocale "%F %T%Q" (B8.unpack bs) of
                   Just t -> t
                   Nothing
                     | SB.isPrefixOf "0000-00-00" bs ->

--- a/Database/MySQL/Simple/Result.hs
+++ b/Database/MySQL/Simple/Result.hs
@@ -39,7 +39,7 @@ import Data.List (foldl')
 import Data.Ratio (Ratio)
 import Data.Time.Calendar (Day, fromGregorian)
 import Data.Time.Clock (UTCTime(..))
-import Data.Time.Format (parseTime)
+import Data.Time.Format (parseTimeM)
 import Data.Time.LocalTime (TimeOfDay, makeTimeOfDayValid)
 import Data.Typeable (TypeRep, Typeable, typeOf)
 import Data.Word (Word, Word8, Word16, Word32, Word64)
@@ -162,7 +162,7 @@ instance Result [Char] where
 
 instance Result UTCTime where
     convert f = doConvert f ok $ \bs ->
-                case parseTime defaultTimeLocale "%F %T" (B8.unpack bs) of
+                case parseTimeM False defaultTimeLocale "%F %T%Q" (B8.unpack bs) of
                   Just t -> t
                   Nothing
                     | SB.isPrefixOf "0000-00-00" bs ->

--- a/mysql-simple.cabal
+++ b/mysql-simple.cabal
@@ -52,7 +52,7 @@ library
     pcre-light,
     old-locale,
     text >= 0.11.0.2,
-    time
+    time >= 1.5
 
   ghc-options: -Wall -fwarn-tabs
   if impl(ghc >= 7.10)

--- a/mysql-simple.cabal
+++ b/mysql-simple.cabal
@@ -52,7 +52,7 @@ library
     pcre-light,
     old-locale,
     text >= 0.11.0.2,
-    time >= 1.5
+    time
 
   ghc-options: -Wall -fwarn-tabs
   if impl(ghc >= 7.10)


### PR DESCRIPTION
E.g., `timestamp(3)` returns an error.