### PR TITLE
Allow UTCTime params to express microseconds.

### DIFF
--- a/Database/MySQL/Simple/Param.hs
+++ b/Database/MySQL/Simple/Param.hs
@@ -190,7 +190,7 @@ instance Param LT.Text where
     {-# INLINE render #-}
 
 instance Param UTCTime where
-    render = Plain . Utf8.fromString . formatTime defaultTimeLocale "'%F %T'"
+    render = Plain . Utf8.fromString . formatTime defaultTimeLocale "'%F %T%Q'"
     {-# INLINE render #-}
 
 instance Param Day where


### PR DESCRIPTION
Change the formatting string when serializing UTCTime params from "'%F %T'" to "'%F %T%Q'". Notably, per the `formatTime` docs, for UTCTime values with a whole number of seconds the "%Q" code will produce the empty string.