### PR TITLE
Allow JSON fields to be read in as ByteStrings

### DIFF
--- a/Database/MySQL/Simple/Result.hs
+++ b/Database/MySQL/Simple/Result.hs
@@ -204,7 +204,7 @@ compat (Compat a) (Compat b) = a .&. b /= 0
 
 okText, ok8, ok16, ok32, ok64, okWord :: Compat
 okText = mkCompats [VarChar,TinyBlob,MediumBlob,LongBlob,Blob,VarString,String,
-                    Set,Enum]
+                    Set,Enum,Json]
 ok8 = mkCompats [Tiny]
 ok16 = mkCompats [Tiny,Short]
 ok32 = mkCompats [Tiny,Short,Int24,Long]

--- a/mysql-simple.cabal
+++ b/mysql-simple.cabal
@@ -50,7 +50,7 @@ library
     blaze-builder,
     bytestring >= 0.9,
     containers,
-    mysql >= 0.1.1.1,
+    mysql >= 0.1.7,
     pcre-light,
     old-locale,
     text >= 0.11.0.2,


### PR DESCRIPTION
Add the `Json` type to `okText` to allow JSON fields to be read in as a `ByteString`