### PR TITLE
Make it easier to use `mysql-simple` with GHC 9.2

### DIFF
--- a/Database/MySQL/Simple/Result.hs
+++ b/Database/MySQL/Simple/Result.hs
@@ -39,7 +39,7 @@ import Data.List (foldl')
 import Data.Ratio (Ratio)
 import Data.Time.Calendar (Day, fromGregorian)
 import Data.Time.Clock (UTCTime(..))
-import Data.Time.Format (parseTime)
+import Data.Time.Format (parseTimeM)
 import Data.Time.LocalTime (TimeOfDay, makeTimeOfDayValid)
 import Data.Typeable (TypeRep, Typeable, typeOf)
 import Data.Word (Word, Word8, Word16, Word32, Word64)
@@ -162,7 +162,7 @@ instance Result [Char] where
 
 instance Result UTCTime where
     convert f = doConvert f ok $ \bs ->
-                case parseTime defaultTimeLocale "%F %T%Q" (B8.unpack bs) of
+                case parseTimeM True defaultTimeLocale "%F %T%Q" (B8.unpack bs) of
                   Just t -> t
                   Nothing
                     | SB.isPrefixOf "0000-00-00" bs ->
@@ -182,7 +182,7 @@ instance Result Day where
 
 instance Result TimeOfDay where
     convert f = doConvert f ok $ \bs ->
-                case parseTime defaultTimeLocale "%T%Q" (B8.unpack bs) of
+                case parseTimeM True defaultTimeLocale "%T%Q" (B8.unpack bs) of
                   Just t -> t
                   _      -> conversionFailed f "TimeOfDay" "could not parse"
         where ok = mkCompats [Time]

--- a/mysql-simple.cabal
+++ b/mysql-simple.cabal
@@ -54,7 +54,7 @@ library
     pcre-light,
     old-locale,
     text >= 0.11.0.2,
-    time
+    time >= 1.5
   if !impl(ghc >= 8.0)
     build-depends:
       semigroups >= 0.11 && < 0.19


### PR DESCRIPTION
This PR replaces uses of the deprecated function `Data.Time.Format.parseTime` with the equivalent `Data.Time.Format.parseTimeM True`.

`parseTime` has been absent from the `time` package since `time-1.10`. With GHC 9.2.1, the version of `time` used by GHC has been [upgraded from `time-1.9.3` to `time-1.11.1.1`](https://gitlab.haskell.org/ghc/ghc/-/wikis/commentary/libraries/version-history), which makes `mysql-simple` difficult to use with GHC 9.2.1. This PR removes that difficulty.