### PR TITLE
JSON support

### DIFF
--- a/Database/MySQL/Simple.hs
+++ b/Database/MySQL/Simple.hs
@@ -50,6 +50,7 @@ module Database.MySQL.Simple
     , In(..)
     , VaArgs(..)
     , Binary(..)
+    , JSON(..)
     , Only(..)
     -- ** Exceptions
     , FormatError(fmtMessage, fmtQuery, fmtParams)
@@ -100,7 +101,7 @@ import Database.MySQL.Simple.Param (Action(..), inQuotes)
 import Database.MySQL.Simple.QueryParams (QueryParams(..))
 import Database.MySQL.Simple.QueryResults (QueryResults(..))
 import Database.MySQL.Simple.Result (ResultError(..))
-import Database.MySQL.Simple.Types (Binary(..), In(..), VaArgs(..), Only(..), Query(..))
+import Database.MySQL.Simple.Types (Binary(..), JSON(..), In(..), VaArgs(..), Only(..), Query(..))
 import Text.Regex.PCRE.Light (compile, caseless, match)
 import qualified Data.ByteString.Char8 as B
 import qualified Database.MySQL.Base as Base

--- a/Database/MySQL/Simple/Param.hs
+++ b/Database/MySQL/Simple/Param.hs
@@ -21,6 +21,8 @@ module Database.MySQL.Simple.Param
 import Blaze.ByteString.Builder (Builder, fromByteString, fromLazyByteString,
                                  toByteString)
 import Blaze.ByteString.Builder.Char8 (fromChar)
+import Data.Aeson (ToJSON)
+import qualified Data.Aeson as Aeson
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Base16.Lazy as L16
@@ -35,7 +37,7 @@ import Data.Time.Format (formatTime)
 import Data.Time.LocalTime (TimeOfDay)
 import Data.Typeable (Typeable)
 import Data.Word (Word, Word8, Word16, Word32, Word64)
-import Database.MySQL.Simple.Types (Binary(..), In(..), VaArgs(..), Null)
+import Database.MySQL.Simple.Types (Binary(..), JSON(..), In(..), VaArgs(..), Null)
 import qualified Blaze.ByteString.Builder.Char.Utf8 as Utf8
 import qualified Data.ByteString as SB
 import qualified Data.ByteString.Lazy as LB
@@ -109,6 +111,9 @@ instance Param (Binary LB.ByteString) where
     render (Binary bs) = Plain $ fromByteString "x'" `mappend`
                                  fromLazyByteString (L16.encode bs) `mappend`
                                  fromChar '\''
+
+instance ToJSON a => Param (JSON a) where
+    render (JSON a) = Escape $ LB.toStrict $ Aeson.encode a
 
 renderNull :: Action
 renderNull = Plain (fromByteString "null")

--- a/Database/MySQL/Simple/Types.hs
+++ b/Database/MySQL/Simple/Types.hs
@@ -123,6 +123,6 @@ newtype VaArgs a = VaArgs a
 newtype Binary a = Binary a
     deriving (Eq, Ord, Read, Show, Typeable, Functor)
 
--- | Wrap a JSON value.
+-- | Wrap a value to be used as JSON.
 newtype JSON a = JSON { fromJSON :: a }
     deriving (Eq, Ord, Read, Show, Typeable, Functor)

--- a/Database/MySQL/Simple/Types.hs
+++ b/Database/MySQL/Simple/Types.hs
@@ -17,6 +17,7 @@ module Database.MySQL.Simple.Types
     , In(..)
     , VaArgs(..)
     , Binary(..)
+    , JSON(..)
     , Query(..)
     ) where
 
@@ -120,4 +121,8 @@ newtype VaArgs a = VaArgs a
 
 -- | Wrap a mostly-binary string to be escaped in hexadecimal.
 newtype Binary a = Binary a
+    deriving (Eq, Ord, Read, Show, Typeable, Functor)
+
+-- | Wrap a JSON value.
+newtype JSON a = JSON { fromJSON :: a }
     deriving (Eq, Ord, Read, Show, Typeable, Functor)

--- a/mysql-simple.cabal
+++ b/mysql-simple.cabal
@@ -44,6 +44,7 @@ library
     Database.MySQL.Internal.Blaze
 
   build-depends:
+    aeson,
     attoparsec >= 0.10.0.0,
     base < 5,
     base16-bytestring,


### PR DESCRIPTION
I added JSON support for both parameters and results. I followed the documentation [here](https://dev.mysql.com/doc/refman/8.0/en/json.html). This adds `aeson` as a dependency.

I haven't throughly tested this yet (will do so soon), but I thought I would post the PR early to see if there's interest in merging something like this in mysql-simple or if I should move this functionality to my code instead.

Thanks.