### PR TITLE
Fix build on ghc 8.4.x

### DIFF
--- a/Database/MySQL/Simple/Result.hs
+++ b/Database/MySQL/Simple/Result.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP, DeriveDataTypeable, FlexibleInstances, OverloadedStrings #-}
-{-# LANGUAGE GeneralisedNewtypeDeriving, DefaultSignatures #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, DefaultSignatures #-}
 #if MIN_VERSION_time(1,5,0)
 {-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
 #endif


### PR DESCRIPTION
The English spelling isn't accepted until ghc 8.6 series.
Caught by glean cI:

https://github.com/facebookincubator/Glean/runs/6646154634?check_suite_focus=true#step:18:704